### PR TITLE
Fix SQL syntax error: Remove OPTION clause from view

### DIFF
--- a/README.md
+++ b/README.md
@@ -772,6 +772,14 @@ WHERE groupId = 'group-guid-here'
 ORDER BY depth;
 ```
 
+**Note:** The view limits recursion depth to 20 levels by default (controlled in the WHERE clause). If you need deeper nesting, you can add `OPTION (MAXRECURSION N)` when querying:
+
+```sql
+SELECT * FROM vw_GraphGroupMembersRecursive
+WHERE groupId = 'group-guid-here'
+OPTION (MAXRECURSION 50);  -- Allow up to 50 levels
+```
+
 **Use case:** "Eliminate the slow transitive members sync and calculate indirect memberships on-demand with complete path information"
 
 #### Examples

--- a/SQL/Initialize-FGGroupMembershipViews.ps1
+++ b/SQL/Initialize-FGGroupMembershipViews.ps1
@@ -405,8 +405,7 @@ SELECT
     ValidFrom,
     ValidTo
 FROM
-    RecursiveMemberships
-OPTION (MAXRECURSION 100);  -- Allow up to 100 levels of recursion
+    RecursiveMemberships;
 "@
 
         $createView4Cmd = $connection.CreateCommand()


### PR DESCRIPTION
SQL Server views cannot contain query hints like OPTION (MAXRECURSION). The depth limit (depth < 20) in the WHERE clause provides protection. Users can add OPTION (MAXRECURSION N) when querying the view if needed.

Error fixed:
- Removed OPTION (MAXRECURSION 100) from view definition
- Updated README to explain how to use OPTION when querying