### PR TITLE
Add organizational unit and administrative units sync support

### DIFF
--- a/FortigiGraph.psd1
+++ b/FortigiGraph.psd1
@@ -12,7 +12,7 @@
 RootModule = '.\FortigiGraph.psm1'
 
 # Version number of this module.
-ModuleVersion = '2.1.20260223.1745'
+ModuleVersion = '2.1.20260224.1430'
 
 # Supported PSEditions
 # CompatiblePSEditions = @()

--- a/Functions/Sync/Sync-FGGroup.ps1
+++ b/Functions/Sync/Sync-FGGroup.ps1
@@ -127,6 +127,7 @@ function Sync-FGGroup {
         'onPremisesSecurityIdentifier'
         'onPremisesNetBiosName'
         'onPremisesDomainName'
+        'onPremisesDistinguishedName'
     )
 
     # Determine which attributes to use
@@ -183,12 +184,13 @@ function Sync-FGGroup {
         'onPremisesSecurityIdentifier' = 'NVARCHAR(255)'
         'onPremisesNetBiosName' = 'NVARCHAR(255)'
         'onPremisesDomainName' = 'NVARCHAR(255)'
+        'onPremisesDistinguishedName' = 'NVARCHAR(1000)'
         'onPremisesProvisioningErrors' = 'NVARCHAR(MAX)'
         'proxyAddresses' = 'NVARCHAR(MAX)'
     }
 
-    # Add calculated field (not a Graph attribute, computed during sync)
-    $calculatedField = 'groupTypeCalculated'
+    # Add calculated fields (not Graph attributes, computed during sync)
+    $calculatedFields = @('groupTypeCalculated', 'organizationalUnit', 'administrativeUnits')
 
     # Build column definitions
     $columns = @{}
@@ -200,8 +202,10 @@ function Sync-FGGroup {
         }
         $columns[$attr] = $sqlType
     }
-    # Add calculated column
-    $columns[$calculatedField] = 'NVARCHAR(100)'
+    # Add calculated columns
+    $columns['groupTypeCalculated'] = 'NVARCHAR(100)'
+    $columns['organizationalUnit'] = 'NVARCHAR(1000)'
+    $columns['administrativeUnits'] = 'NVARCHAR(MAX)'
 
     # Check if table exists and handle schema
     try {
@@ -217,7 +221,7 @@ function Sync-FGGroup {
 
     # Ensure attributes needed for groupTypeCalculated are always fetched from Graph
     $graphAttributes = $Attributes
-    foreach ($required in @('groupTypes', 'securityEnabled', 'mailEnabled', 'resourceProvisioningOptions', 'membershipRule')) {
+    foreach ($required in @('groupTypes', 'securityEnabled', 'mailEnabled', 'resourceProvisioningOptions', 'membershipRule', 'onPremisesDistinguishedName')) {
         if ($graphAttributes -notcontains $required) {
             $graphAttributes += $required
         }
@@ -250,18 +254,47 @@ function Sync-FGGroup {
         return
     }
 
+    # Fetch administrative unit memberships
+    $auMemberMap = @{}
+    Write-Host "`n[$(Get-Date -Format 'HH:mm:ss')] Fetching administrative unit memberships..." -ForegroundColor Cyan
+    try {
+        $auUri = "https://graph.microsoft.com/v1.0/directory/administrativeUnits?`$select=id,displayName"
+        $allAUs = Invoke-FGGetRequest -URI $auUri
+        if ($allAUs) {
+            foreach ($au in $allAUs) {
+                $membersUri = "https://graph.microsoft.com/v1.0/directory/administrativeUnits/$($au.id)/members?`$select=id"
+                $members = Invoke-FGGetRequest -URI $membersUri
+                if ($members) {
+                    foreach ($member in $members) {
+                        if (-not $auMemberMap.ContainsKey($member.id)) {
+                            $auMemberMap[$member.id] = @()
+                        }
+                        $auMemberMap[$member.id] += $au.displayName
+                    }
+                }
+            }
+            Write-Host "[$(Get-Date -Format 'HH:mm:ss')] Found $($allAUs.Count) administrative unit(s) with $($auMemberMap.Count) member assignments" -ForegroundColor Green
+        }
+        else {
+            Write-Host "[$(Get-Date -Format 'HH:mm:ss')] No administrative units found" -ForegroundColor Gray
+        }
+    }
+    catch {
+        Write-Warning "[$(Get-Date -Format 'HH:mm:ss')] Failed to fetch administrative units: $_. The 'administrativeUnits' column will be empty."
+    }
+
     # Sync to SQL using bulk operations (HIGH PERFORMANCE)
     Write-Host "`n[$(Get-Date -Format 'HH:mm:ss')] Syncing groups to SQL Server..." -ForegroundColor Cyan
 
     # Build DataTable for bulk operations
     Write-Host "[$(Get-Date -Format 'HH:mm:ss')] Preparing data for bulk sync..." -ForegroundColor Gray
 
-    # Include calculated field in the attribute list for DataTable creation
-    $allColumns = $Attributes + @($calculatedField)
+    # Include calculated fields in the attribute list for DataTable creation
+    $allColumns = $Attributes + $calculatedFields
 
-    # Define a resolver for the calculated groupTypeCalculated field
+    # Define resolvers for the calculated fields
     $valueResolvers = @{
-        $calculatedField = {
+        'groupTypeCalculated' = {
             param($obj)
             $groupTypesValue = $obj.groupTypes
             $isUnified = $groupTypesValue -is [Array] -and $groupTypesValue -contains 'Unified'
@@ -275,6 +308,25 @@ function Sync-FGGroup {
             else { $baseType = 'Mail Enabled Security Group' }
 
             if ($isDynamic) { "Dynamic $baseType" } else { $baseType }
+        }
+        'organizationalUnit' = {
+            param($obj)
+            $dn = $obj.onPremisesDistinguishedName
+            if (-not $dn) { return $null }
+            $parts = $dn -split '(?<!\\),'
+            $ouParts = @($parts | Where-Object { $_ -match '^OU=' } | ForEach-Object { $_ -replace '^OU=', '' })
+            if ($ouParts.Count -gt 0) {
+                [array]::Reverse($ouParts)
+                return ($ouParts -join '/')
+            }
+            return $null
+        }
+        'administrativeUnits' = {
+            param($obj)
+            if ($auMemberMap.ContainsKey($obj.id)) {
+                return ($auMemberMap[$obj.id] -join ', ')
+            }
+            return $null
         }
     }
 

--- a/Functions/Sync/Sync-FGUser.ps1
+++ b/Functions/Sync/Sync-FGUser.ps1
@@ -101,6 +101,12 @@ function Sync-FGUser {
         'mail'
         'onPremisesDistinguishedName'
 
+        # Computed: OU path extracted from onPremisesDistinguishedName
+        'organizationalUnit'
+
+        # Computed: Entra ID Administrative Units (fetched separately)
+        'administrativeUnits'
+
         # Status
         'accountEnabled'
         'userType'
@@ -189,6 +195,8 @@ function Sync-FGUser {
         'preferredLanguage' = 'NVARCHAR(50)'
         'userType' = 'NVARCHAR(50)'
         'managerId' = 'UNIQUEIDENTIFIER'
+        'organizationalUnit' = 'NVARCHAR(1000)'
+        'administrativeUnits' = 'NVARCHAR(MAX)'
     }
 
     # Build column definitions
@@ -214,10 +222,17 @@ function Sync-FGUser {
     # Build Graph API request
     Write-Host "`n[$(Get-Date -Format 'HH:mm:ss')] Fetching users from Microsoft Graph..." -ForegroundColor Cyan
 
-    # Remove special attributes that need expand or separate handling
-    $regularAttributes = $Attributes | Where-Object { $_ -notin @('managerId', 'lastSignInDateTime') }
+    # Remove special attributes that need expand, separate handling, or are computed
+    $regularAttributes = $Attributes | Where-Object { $_ -notin @('managerId', 'lastSignInDateTime', 'organizationalUnit', 'administrativeUnits') }
     $needsManager = $Attributes -contains 'managerId'
     $needsSignInActivity = $Attributes -contains 'lastSignInDateTime'
+    $needsOU = $Attributes -contains 'organizationalUnit'
+    $needsAU = $Attributes -contains 'administrativeUnits'
+
+    # Ensure onPremisesDistinguishedName is fetched from Graph if organizationalUnit is requested
+    if ($needsOU -and $regularAttributes -notcontains 'onPremisesDistinguishedName') {
+        $regularAttributes += 'onPremisesDistinguishedName'
+    }
 
     $selectProperties = $regularAttributes -join ','
     $uri = "https://graph.microsoft.com/v1.0/users?`$select=$selectProperties"
@@ -260,6 +275,37 @@ function Sync-FGUser {
         return
     }
 
+    # Fetch administrative unit memberships if needed
+    $auMemberMap = @{}
+    if ($needsAU) {
+        Write-Host "`n[$(Get-Date -Format 'HH:mm:ss')] Fetching administrative unit memberships..." -ForegroundColor Cyan
+        try {
+            $auUri = "https://graph.microsoft.com/v1.0/directory/administrativeUnits?`$select=id,displayName"
+            $allAUs = Invoke-FGGetRequest -URI $auUri
+            if ($allAUs) {
+                foreach ($au in $allAUs) {
+                    $membersUri = "https://graph.microsoft.com/v1.0/directory/administrativeUnits/$($au.id)/members?`$select=id"
+                    $members = Invoke-FGGetRequest -URI $membersUri
+                    if ($members) {
+                        foreach ($member in $members) {
+                            if (-not $auMemberMap.ContainsKey($member.id)) {
+                                $auMemberMap[$member.id] = @()
+                            }
+                            $auMemberMap[$member.id] += $au.displayName
+                        }
+                    }
+                }
+                Write-Host "[$(Get-Date -Format 'HH:mm:ss')] Found $($allAUs.Count) administrative unit(s) with $($auMemberMap.Count) member assignments" -ForegroundColor Green
+            }
+            else {
+                Write-Host "[$(Get-Date -Format 'HH:mm:ss')] No administrative units found" -ForegroundColor Gray
+            }
+        }
+        catch {
+            Write-Warning "[$(Get-Date -Format 'HH:mm:ss')] Failed to fetch administrative units: $_. The 'administrativeUnits' column will be empty."
+        }
+    }
+
     # Sync to SQL using bulk operations (HIGH PERFORMANCE)
     Write-Host "`n[$(Get-Date -Format 'HH:mm:ss')] Syncing users to SQL Server..." -ForegroundColor Cyan
 
@@ -270,6 +316,25 @@ function Sync-FGUser {
     $valueResolvers = @{
         'managerId' = { param($obj) if ($obj.manager -and $obj.manager.id) { [guid]$obj.manager.id } else { $null } }
         'lastSignInDateTime' = { param($obj) if ($obj.signInActivity -and $obj.signInActivity.lastSignInDateTime) { [datetime]$obj.signInActivity.lastSignInDateTime } else { $null } }
+        'organizationalUnit' = {
+            param($obj)
+            $dn = $obj.onPremisesDistinguishedName
+            if (-not $dn) { return $null }
+            $parts = $dn -split '(?<!\\),'
+            $ouParts = @($parts | Where-Object { $_ -match '^OU=' } | ForEach-Object { $_ -replace '^OU=', '' })
+            if ($ouParts.Count -gt 0) {
+                [array]::Reverse($ouParts)
+                return ($ouParts -join '/')
+            }
+            return $null
+        }
+        'administrativeUnits' = {
+            param($obj)
+            if ($auMemberMap.ContainsKey($obj.id)) {
+                return ($auMemberMap[$obj.id] -join ', ')
+            }
+            return $null
+        }
     }
 
     $dataTable = New-FGDataTableFromGraphObjects -GraphObjects $allUsers -Columns $columns -Attributes $Attributes -ValueResolvers $valueResolvers


### PR DESCRIPTION
## Summary
This PR adds support for syncing organizational unit (OU) paths and administrative unit memberships for both users and groups. These are computed fields derived from existing Microsoft Graph data.

## Key Changes

**Sync-FGGroup.ps1:**
- Added `onPremisesDistinguishedName` to the list of attributes to sync from Graph
- Added database columns for `organizationalUnit` (NVARCHAR(1000)) and `administrativeUnits` (NVARCHAR(MAX))
- Implemented logic to fetch administrative unit memberships from the directory
- Added value resolvers to compute:
  - `organizationalUnit`: Extracts and formats the OU path from the distinguished name (e.g., "OU1/OU2/OU3")
  - `administrativeUnits`: Maps group IDs to their assigned administrative units (comma-separated)

**Sync-FGUser.ps1:**
- Added `organizationalUnit` and `administrativeUnits` to the default attributes list with documentation
- Added database columns for both computed fields
- Implemented conditional fetching of administrative unit memberships (only when requested)
- Ensures `onPremisesDistinguishedName` is fetched from Graph when `organizationalUnit` is requested
- Added identical value resolvers for computing OU paths and administrative unit assignments

**FortigiGraph.psd1:**
- Updated module version to reflect the changes

## Implementation Details

- **OU Path Extraction**: Uses regex-based parsing of distinguished names to extract OU components, reverses them to create a hierarchical path format (root to leaf), and handles escaped commas in DNs
- **Administrative Units**: Fetches all administrative units and their members in a single operation, building a map for efficient lookup during data table creation
- **Error Handling**: Gracefully handles failures in fetching administrative units with appropriate warning messages
- **Performance**: Administrative unit fetching is conditional in users sync (only when requested) but always performed for groups
- **Consistency**: Both user and group sync functions use identical logic for computing these fields

https://claude.ai/code/session_01JthmA8TPfzLnLRHdZ8WnvG