### PR TITLE
Fix composite primary key parameter and remove unused attribute

### DIFF
--- a/FortigiGraph.psd1
+++ b/FortigiGraph.psd1
@@ -12,7 +12,7 @@
 RootModule = '.\FortigiGraph.psm1'
 
 # Version number of this module.
-ModuleVersion = '2.2.20260224.1430'
+ModuleVersion = '2.2.20260228.0830'
 
 # Supported PSEditions
 # CompatiblePSEditions = @()

--- a/Functions/Sync/Initialize-FGSyncTable.ps1
+++ b/Functions/Sync/Initialize-FGSyncTable.ps1
@@ -96,7 +96,7 @@ function Initialize-FGSyncTable {
         }
 
         if ($CompositePrimaryKey) {
-            $initParams.CompositePrimaryKey = $CompositePrimaryKey
+            $initParams.PrimaryKey = $CompositePrimaryKey
         }
         else {
             $initParams.PrimaryKey = $PrimaryKey

--- a/Functions/Sync/Sync-FGGroup.ps1
+++ b/Functions/Sync/Sync-FGGroup.ps1
@@ -128,7 +128,6 @@ function Sync-FGGroup {
         'onPremisesSecurityIdentifier'
         'onPremisesNetBiosName'
         'onPremisesDomainName'
-        'onPremisesDistinguishedName'
     )
 
     # Determine which attributes to use


### PR DESCRIPTION
## Summary
This PR includes bug fixes and cleanup for the FortigiGraph module, addressing a parameter naming issue in table initialization and removing an unused attribute from group synchronization.

## Key Changes
- **Fixed composite primary key parameter**: Changed `$initParams.CompositePrimaryKey` to `$initParams.PrimaryKey` in `Initialize-FGSyncTable.ps1` to use the correct parameter name
- **Removed unused attribute**: Removed `'onPremisesDistinguishedName'` from the attributes list in `Sync-FGGroup.ps1` as it is no longer needed
- **Updated module version**: Bumped version from `2.2.20260224.1430` to `2.2.20260228.0830`

## Implementation Details
The composite primary key fix ensures that when a composite primary key is provided to the sync table initialization function, it is properly assigned to the correct parameter name that the underlying system expects. The removal of the distinguished name attribute simplifies the group synchronization process by eliminating an unused field from the attribute collection.

https://claude.ai/code/session_01DQtjeSsgfLP13yfXvMmUc2