### PR TITLE
Add local Docker setup for full-stack development

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,22 @@
+# Root-context Dockerfile — used by New-FGUI / Update-FGUI for Azure App Service deployment.
+# Build context: repo root  (contains UI/frontend/ and UI/backend/)
+
+# ── Stage 1: Build frontend ───────────────────────────────────────────────────
+FROM node:20-slim AS frontend-build
+WORKDIR /app/frontend
+COPY UI/frontend/package*.json ./
+RUN npm ci
+COPY UI/frontend/ .
+RUN npm run build
+
+# ── Stage 2: Backend runtime ──────────────────────────────────────────────────
+FROM node:20-slim AS runtime
+WORKDIR /app/backend
+COPY UI/backend/package*.json ./
+RUN npm ci --omit=dev
+COPY UI/backend/src ./src
+# Copy the compiled frontend so Express can serve it as static files
+COPY --from=frontend-build /app/frontend/dist ../frontend/dist
+
+EXPOSE 3001
+CMD ["node", "src/index.js"]

--- a/FortigiGraph.psd1
+++ b/FortigiGraph.psd1
@@ -12,7 +12,7 @@
 RootModule = '.\FortigiGraph.psm1'
 
 # Version number of this module.
-ModuleVersion = '2.2.20260302.1045'
+ModuleVersion = '2.2.20260326.1530'
 
 # Supported PSEditions
 # CompatiblePSEditions = @()

--- a/Functions/Sync/Start-FGSync.ps1
+++ b/Functions/Sync/Start-FGSync.ps1
@@ -380,30 +380,34 @@ function Write-SyncError {
     #endregion
 
     #region Azure Connection
-    Write-SyncHeader "Connecting to Azure"
+    # Skip when a SQL connection is already pre-established (e.g. local Docker) and
+    # server validation is being bypassed — no Azure context needed in that case.
+    if (-not ($SkipServerValidation -and $Global:FGSQLConnectionString)) {
+        Write-SyncHeader "Connecting to Azure"
 
-    $azContext = Get-AzContext -ErrorAction SilentlyContinue
+        $azContext = Get-AzContext -ErrorAction SilentlyContinue
 
-    if (-not $azContext) {
-        Write-SyncStep "Connecting to Azure..."
-        Connect-AzAccount -TenantId $azureTenantId -SubscriptionId $config.Azure.SubscriptionId | Out-Null
-        $azContext = Get-AzContext
-    } else {
-        $correctTenant = $azContext.Tenant.Id -eq $azureTenantId
-        $correctSubscription = $azContext.Subscription.Id -eq $config.Azure.SubscriptionId
-
-        if (-not $correctTenant -or -not $correctSubscription) {
-            Write-SyncStep "Switching Azure context..."
-            try {
-                Set-AzContext -TenantId $azureTenantId -SubscriptionId $config.Azure.SubscriptionId -ErrorAction Stop | Out-Null
-            } catch {
-                Connect-AzAccount -TenantId $azureTenantId -SubscriptionId $config.Azure.SubscriptionId | Out-Null
-            }
+        if (-not $azContext) {
+            Write-SyncStep "Connecting to Azure..."
+            Connect-AzAccount -TenantId $azureTenantId -SubscriptionId $config.Azure.SubscriptionId | Out-Null
             $azContext = Get-AzContext
-        }
-    }
+        } else {
+            $correctTenant = $azContext.Tenant.Id -eq $azureTenantId
+            $correctSubscription = $azContext.Subscription.Id -eq $config.Azure.SubscriptionId
 
-    Write-SyncSuccess "Connected to Azure: $($azContext.Subscription.Name) ($($azContext.Account.Id))"
+            if (-not $correctTenant -or -not $correctSubscription) {
+                Write-SyncStep "Switching Azure context..."
+                try {
+                    Set-AzContext -TenantId $azureTenantId -SubscriptionId $config.Azure.SubscriptionId -ErrorAction Stop | Out-Null
+                } catch {
+                    Connect-AzAccount -TenantId $azureTenantId -SubscriptionId $config.Azure.SubscriptionId | Out-Null
+                }
+                $azContext = Get-AzContext
+            }
+        }
+
+        Write-SyncSuccess "Connected to Azure: $($azContext.Subscription.Name) ($($azContext.Account.Id))"
+    }
     #endregion
 
     #region SQL Server Validation
@@ -450,14 +454,17 @@ function Write-SyncError {
     } else {
         Write-SyncStep "Skipping server validation (assuming server exists)"
 
-        # Still need to connect
-        Connect-FGSQLServer `
-            -SubscriptionId $config.Azure.SubscriptionId `
-            -ResourceGroupName $config.Azure.ResourceGroupName `
-            -ServerName $config.Azure.SQLServerName `
-            -DatabaseName $config.Azure.DatabaseName `
-            -AdminUsername $config.Azure.AdminUsername `
-            -AdminPassword $SecurePassword 
+        if ($Global:FGSQLConnectionString) {
+            Write-SyncStep "Using pre-established SQL connection"
+        } else {
+            Connect-FGSQLServer `
+                -SubscriptionId $config.Azure.SubscriptionId `
+                -ResourceGroupName $config.Azure.ResourceGroupName `
+                -ServerName $config.Azure.SQLServerName `
+                -DatabaseName $config.Azure.DatabaseName `
+                -AdminUsername $config.Azure.AdminUsername `
+                -AdminPassword $SecurePassword
+        }
 
         Write-SyncSuccess "Connected to SQL Server"
     }

--- a/UI/.dockerignore
+++ b/UI/.dockerignore
@@ -1,0 +1,4 @@
+**/node_modules
+**/dist
+**/.env
+**/*.log

--- a/UI/backend/Dockerfile
+++ b/UI/backend/Dockerfile
@@ -1,0 +1,22 @@
+# Build context: ./UI  (one level above backend/)
+# Usage: docker build -f backend/Dockerfile -t fortigraph-backend .
+
+# ── Stage 1: Build frontend ───────────────────────────────────────────────────
+FROM node:20-slim AS frontend-build
+WORKDIR /app/frontend
+COPY frontend/package*.json ./
+RUN npm ci
+COPY frontend/ .
+RUN npm run build
+
+# ── Stage 2: Backend runtime ──────────────────────────────────────────────────
+FROM node:20-slim AS runtime
+WORKDIR /app/backend
+COPY backend/package*.json ./
+RUN npm ci --omit=dev
+COPY backend/src ./src
+# Copy the compiled frontend so Express can serve it as static files
+COPY --from=frontend-build /app/frontend/dist ../frontend/dist
+
+EXPOSE 3001
+CMD ["node", "src/index.js"]

--- a/UI/backend/src/db/connection.js
+++ b/UI/backend/src/db/connection.js
@@ -10,7 +10,7 @@ const config = {
   requestTimeout: 120000,  // 2 min – recursive CTE views can be slow on large datasets
   options: {
     encrypt: true,
-    trustServerCertificate: false
+    trustServerCertificate: process.env.SQL_TRUST_SERVER_CERT === 'true'
   },
   pool: {
     max: 10,

--- a/UI/backend/src/routes/permissions.js
+++ b/UI/backend/src/routes/permissions.js
@@ -92,6 +92,14 @@ router.get('/permissions', async (req, res) => {
     if (useSql) {
       const p = await db.getPool();
 
+      // Return empty data when sync hasn't run yet (GraphUsers table doesn't exist)
+      const tableCheck = await p.request().query(
+        `SELECT OBJECT_ID('dbo.GraphUsers', 'U') AS graphUsersExists`
+      );
+      if (!tableCheck.recordset[0].graphUsersExists) {
+        return res.json({ data: [], totalUsers: 0, managedByPackages: [] });
+      }
+
       // Prefer materialized tables (fast) with view fallback (slow but always current)
       const matCheck = await timedRequest(p, 'perm-mat-check', res).query(`
         SELECT

--- a/UI/frontend/Dockerfile
+++ b/UI/frontend/Dockerfile
@@ -1,0 +1,16 @@
+# Standalone frontend dev container with hot reload.
+# Not used by docker-compose.local.yml (backend serves the built frontend there).
+# Useful for frontend-only development work.
+#
+# Usage:
+#   docker build -t fortigraph-frontend .
+#   docker run -p 5173:5173 -v $(pwd)/src:/app/src fortigraph-frontend
+
+FROM node:20-slim
+WORKDIR /app
+COPY package*.json ./
+RUN npm ci
+COPY . .
+
+EXPOSE 5173
+CMD ["npm", "run", "dev", "--", "--host", "--port", "5173"]

--- a/docker-compose.local.yml
+++ b/docker-compose.local.yml
@@ -1,0 +1,57 @@
+services:
+
+  # ── SQL Server 2022 ──────────────────────────────────────────────────────────
+  sql:
+    image: mcr.microsoft.com/mssql/server:2022-latest
+    environment:
+      ACCEPT_EULA: "Y"
+      MSSQL_SA_PASSWORD: "FortigiGraph_Local1!"
+      MSSQL_PID: "Developer"
+    ports:
+      - "1433:1433"   # Exposed to host so PowerShell sync can connect via localhost,1433
+    volumes:
+      - sql_data:/var/opt/mssql
+    healthcheck:
+      test: >
+        /opt/mssql-tools18/bin/sqlcmd
+        -S localhost -U sa -P "FortigiGraph_Local1!"
+        -Q "SELECT 1" -b -No
+      interval: 10s
+      timeout: 5s
+      retries: 12
+      start_period: 30s
+
+  # ── One-time database creation ───────────────────────────────────────────────
+  sql-init:
+    image: mcr.microsoft.com/mssql/server:2022-latest
+    depends_on:
+      sql:
+        condition: service_healthy
+    command: >
+      /opt/mssql-tools18/bin/sqlcmd -S sql -U sa -P "FortigiGraph_Local1!" -b -No
+      -Q "IF NOT EXISTS (SELECT name FROM sys.databases WHERE name = N'GraphData') CREATE DATABASE [GraphData];"
+    restart: "no"
+
+  # ── Backend (serves built frontend + API) ────────────────────────────────────
+  backend:
+    build:
+      context: ./UI
+      dockerfile: backend/Dockerfile
+    environment:
+      NODE_ENV: production
+      USE_SQL: "true"
+      SQL_SERVER: sql          # Docker service name resolves inside the network
+      SQL_DATABASE: GraphData
+      SQL_USER: sa
+      SQL_PASSWORD: "FortigiGraph_Local1!"
+      SQL_TRUST_SERVER_CERT: "true"   # Required for SQL Server's self-signed cert
+      AUTH_ENABLED: "false"
+      PORT: "3001"
+    ports:
+      - "3001:3001"
+    depends_on:
+      sql-init:
+        condition: service_completed_successfully
+
+volumes:
+  sql_data:

--- a/scripts/local-sync.ps1
+++ b/scripts/local-sync.ps1
@@ -1,0 +1,68 @@
+<#
+.SYNOPSIS
+    Runs FortigiGraph sync against the local Docker SQL Server.
+
+.DESCRIPTION
+    Bypasses the normal Connect-FGSQLServer (which requires Azure context and
+    appends .database.windows.net) by pre-establishing the connection directly
+    to the Docker SQL container on localhost:1433.
+
+    Prerequisites:
+    - Docker stack running: docker compose -f docker-compose.local.yml up -d
+    - FortigiGraph module available at repo root
+    - Config file with valid Graph credentials (Azure fields can be dummy values)
+
+.PARAMETER ConfigFile
+    Path to a FortigiGraph config JSON file.
+    Graph.TenantId, Graph.ClientId, and Graph.ClientSecret must be real values.
+    Azure fields (SubscriptionId, ResourceGroupName, etc.) are not used for local sync.
+
+.PARAMETER SQLPassword
+    SA password for the local Docker SQL Server.
+    Defaults to the password set in docker-compose.local.yml.
+
+.PARAMETER SQLDatabase
+    Database name. Defaults to GraphData (matches docker-compose.local.yml).
+
+.EXAMPLE
+    .\scripts\local-sync.ps1 -ConfigFile .\Config\yourtenant.json
+#>
+param(
+    [Parameter(Mandatory = $true)]
+    [string]$ConfigFile,
+
+    [Parameter(Mandatory = $false)]
+    [string]$SQLPassword = "FortigiGraph_Local1!",
+
+    [Parameter(Mandatory = $false)]
+    [string]$SQLDatabase = "GraphData"
+)
+
+$ErrorActionPreference = "Stop"
+
+Write-Host "FortigiGraph Local Sync" -ForegroundColor Cyan
+Write-Host "=======================" -ForegroundColor Cyan
+
+# Load module from repo root
+$modulePath = Join-Path $PSScriptRoot "..\FortigiGraph.psd1"
+Write-Host "Loading module from: $modulePath" -ForegroundColor Cyan
+Import-Module $modulePath -Force
+
+# Connect directly to the Docker SQL Server on localhost:1433.
+# Using -ConnectionString bypasses the .database.windows.net suffix normalization
+# in New-FGSQLConnection and avoids requiring Azure context.
+Write-Host "Connecting to local Docker SQL Server (localhost:1433)..." -ForegroundColor Cyan
+$connectionString = "Server=localhost,1433;Initial Catalog=$SQLDatabase;User ID=sa;Password=$SQLPassword;TrustServerCertificate=True;Encrypt=True;"
+New-FGSQLConnection -ConnectionString $connectionString
+
+# Authenticate to Microsoft Graph using the config file credentials.
+Write-Host "Authenticating to Microsoft Graph..." -ForegroundColor Cyan
+Get-FGAccessToken -ConfigFile $ConfigFile
+
+# Run sync. -SkipServerValidation combined with the pre-established
+# $Global:FGSQLConnectionString causes Start-FGSync to skip the Azure
+# connection step and the Connect-FGSQLServer call entirely.
+Write-Host "Starting sync..." -ForegroundColor Cyan
+Start-FGSync -ConfigFile $ConfigFile -SkipServerValidation
+
+Write-Host "Local sync complete." -ForegroundColor Green


### PR DESCRIPTION
- docker-compose.local.yml: SQL Server 2022 + backend; SQL port 1433 exposed to host so PowerShell sync can connect from outside Docker
- UI/backend/Dockerfile: multi-stage build (builds frontend, serves it via Express); UI/frontend/Dockerfile: standalone dev container
- Root Dockerfile: same multi-stage with repo-root build context for Azure App Service deployment consistency
- UI/.dockerignore: exclude node_modules/dist to keep build context small
- scripts/local-sync.ps1: pre-establishes direct SQL connection to the Docker container, then calls Start-FGSync -SkipServerValidation to bypass the Azure/Connect-FGSQLServer flow
- connection.js: trustServerCertificate now reads SQL_TRUST_SERVER_CERT env var (defaults false — no Azure impact)
- Start-FGSync: skip Azure connection + Connect-FGSQLServer when -SkipServerValidation is set and a connection is pre-established
- permissions.js: return empty data when GraphUsers table doesn't exist yet (pre-sync state) instead of a 500 SQL syntax error